### PR TITLE
Use official node:alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:latest
+FROM node:alpine
 MAINTAINER Keymetrics <contact@keymetrics.io>
 
 RUN npm install pm2 -g


### PR DESCRIPTION
Hello, @Unitech 
Check this:
https://github.com/mhart/alpine-node/issues/76
https://github.com/nodejs/docker-node/pull/156

The official one also have less CVE issues (whit the one from @mhart Docker Cloud reports lots of CVE).

Best regards,
Simone