### PR TITLE
Add support to more node.JS versions

### DIFF
--- a/4.7/Dockerfile
+++ b/4.7/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:4-alpine
+MAINTAINER Keymetrics <contact@keymetrics.io>
+
+RUN npm install pm2 -g
+
+VOLUME ["/app"]
+
+# Expose ports
+EXPOSE 80 443 43554
+
+WORKDIR /app
+
+# Start process.yml
+CMD ["pm2-docker", "start", "--auto-exit", "--env", "production", "process.yml"]

--- a/6.9/Dockerfile
+++ b/6.9/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:6-alpine
+MAINTAINER Keymetrics <contact@keymetrics.io>
+
+RUN npm install pm2 -g
+
+VOLUME ["/app"]
+
+# Expose ports
+EXPOSE 80 443 43554
+
+WORKDIR /app
+
+# Start process.yml
+CMD ["pm2-docker", "start", "--auto-exit", "--env", "production", "process.yml"]

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:7-alpine
+MAINTAINER Keymetrics <contact@keymetrics.io>
+
+RUN npm install pm2 -g
+
+VOLUME ["/app"]
+
+# Expose ports
+EXPOSE 80 443 43554
+
+WORKDIR /app
+
+# Start process.yml
+CMD ["pm2-docker", "start", "--auto-exit", "--env", "production", "process.yml"]

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ $ docker pull keymetrics/pm2-docker-alpine
 
 Versions available:
 
-- keymetrics/pm2-docker-alpine:latest with Node.js 6
-- keymetrics/pm2-docker-alpine:4 with Node.js 4
-- keymetrics/pm2-docker-alpine:0.12 with Node.js 0.12
+- keymetrics/pm2-docker-alpine:latest with the latest version of Node.js
+- keymetrics/pm2-docker-alpine:7 with Node.js 7.4
+- keymetrics/pm2-docker-alpine:6 with Node.js 6.9
+- keymetrics/pm2-docker-alpine:4 with Node.js 4.7
 
-These images are automatically built from the Docker hub based on this Github repository branch arrangement.
+These images are automatically built from the Docker hub based on this Github repository folder arrangement.
 
 [Hub link](https://hub.docker.com/r/keymetrics/pm2-docker-alpine/)
 


### PR DESCRIPTION
This should close:
https://github.com/keymetrics/pm2-docker-alpine/issues/10
More info here:
https://github.com/keymetrics/pm2-docker-alpine/pull/11