### PR TITLE
MAINTAINER switch to LABEL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:alpine
-MAINTAINER Keymetrics <contact@keymetrics.io>
+LABEL maintainer "Keymetrics <contact@keymetrics.io>"
 
 RUN npm install pm2 -g
 


### PR DESCRIPTION
Since the MAINTAINER command is deprecated now, it's better to use the LABEL command instead of MAINTAINER one as mentioned here : https://docs.docker.com/engine/reference/builder/#maintainer-deprecated